### PR TITLE
Improve ComposableEventParameterNaming message

### DIFF
--- a/src/main/kotlin/ru/kode/detekt/rule/compose/ComposableEventParameterNaming.kt
+++ b/src/main/kotlin/ru/kode/detekt/rule/compose/ComposableEventParameterNaming.kt
@@ -64,15 +64,16 @@ class ComposableEventParameterNaming(config: Config = Config.empty) : Rule(confi
   }
 
   private fun reportError(node: KtParameter) {
-    val usesPastTense = node.name!!.startsWith("on") && node.name!!.endsWith("ed")
+    val name = node.name!!
+    val usesPastTense = name.startsWith("on") && name.endsWith("ed")
     report(
       CodeSmell(
         issue,
         Entity.from(node),
         if (usesPastTense) {
-          "Invalid event parameter name. Do not use past tense. For example: \"onClicked\" → \"onClick\""
+          "Invalid event parameter name `${name}`. Do not use past tense. For example: \"onClicked\" → \"onClick\""
         } else {
-          "Invalid event parameter name. Use names like \"onClick\", \"onValueChange\" etc"
+          "Invalid event parameter name `${name}`. Use names like \"onClick\", \"onValueChange\" etc"
         }
       )
     )


### PR DESCRIPTION
Fixes #2

I didn't implement any test because I saw that you aren't testing the messages (and on detekt we don't usually test that either). But let me now if you prefer if I test it.