### PR TITLE
Implement ComposeFunctionName

### DIFF
--- a/src/main/kotlin/ru/kode/detekt/rule/compose/ComposeFunctionName.kt
+++ b/src/main/kotlin/ru/kode/detekt/rule/compose/ComposeFunctionName.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 KODE LLC. Use of this source code is governed by the MIT license.
+ */
+package ru.kode.detekt.rule.compose
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import io.gitlab.arturbosch.detekt.rules.isOverride
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * The Composable functions that return Unit should start with upper-case while the ones that return a value should
+ * start with lower case.
+ *
+ * Wrong:
+ * ```
+ * @Composable
+ * fun button() {
+ *   ...
+ * }
+ * ```
+ * Correct:
+ * ```
+ * @Composable
+ * fun Button() {
+ *   ...
+ * }
+ * ```
+ *
+ * Wrong:
+ * ```
+ * @Composable
+ * fun Value(): Int = ...
+ * ```
+ * Correct:
+ * ```
+ * @Composable
+ * fun value(): Int = ...
+ * ```
+ *
+ * **See also: [Compose api guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#naming-unit-composable-functions-as-entities)
+ */
+class ComposeFunctionName(config: Config = Config.empty) : Rule(config) {
+  override val issue = Issue(
+    javaClass.simpleName,
+    Severity.Defect,
+    "Incorrect composable function name",
+    Debt.FIVE_MINS
+  )
+
+  override fun visitNamedFunction(function: KtNamedFunction) {
+    super.visitNamedFunction(function)
+    if (function.isOverride()) return
+    if (!function.hasAnnotation("Composable")) return
+
+    if (function.returnsUnit()) {
+      reportIfStartWithLowerCase(function)
+    } else {
+      reportIfStartWithUpperCase(function)
+    }
+  }
+
+  private fun reportIfStartWithLowerCase(function: KtNamedFunction) {
+    val name = function.name ?: return
+    if (name.first().isLowerCase()) {
+      report(CodeSmell(issue, Entity.atName(function), "Composable function '$name' should start with upper case"))
+    }
+  }
+
+  private fun reportIfStartWithUpperCase(function: KtNamedFunction) {
+    val name = function.name ?: return
+    if (name.first().isUpperCase()) {
+      report(CodeSmell(issue, Entity.atName(function), "Composable function '$name' should start with lower case"))
+    }
+  }
+}
+
+private fun KtNamedFunction.returnsUnit(): Boolean {
+  val typeReference = typeReference
+  return if (typeReference == null) {
+    // I'm assuming that any function without block body and not defined type should not return `Unit`.
+    // I think that's a safe call. This is the best we can do without type solving
+    hasBlockBody()
+  } else {
+    typeReference.text == "Unit"
+  }
+}

--- a/src/main/kotlin/ru/kode/detekt/rule/compose/ComposeRuleSetProvider.kt
+++ b/src/main/kotlin/ru/kode/detekt/rule/compose/ComposeRuleSetProvider.kt
@@ -20,7 +20,8 @@ class ComposeRuleSetProvider : RuleSetProvider {
         ComposableParametersOrdering(config),
         ModifierDefaultValue(config),
         MissingModifierDefaultValue(config),
-        TopLevelComposableFunctions(config)
+        TopLevelComposableFunctions(config),
+        ComposeFunctionName(config)
       )
     )
   }

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -20,3 +20,5 @@ compose:
     active: true
   TopLevelComposableFunctions:
     active: false
+  ComposeFunctionName:
+    active: true

--- a/src/test/kotlin/ru/kode/detekt/rule/compose/ComposeFunctionNameTest.kt
+++ b/src/test/kotlin/ru/kode/detekt/rule/compose/ComposeFunctionNameTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 KODE LLC. Use of this source code is governed by the MIT license.
+ */
+package ru.kode.detekt.rule.compose
+
+import io.gitlab.arturbosch.detekt.test.lint
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+
+class ComposeFunctionNameTest : ShouldSpec({
+  should("report when returns Unit and starts with lower case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun test(modifier: Modifier) {
+        Text(text = "3")
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings shouldHaveSize 1
+  }
+
+  should("report when returns Unit explicitly and starts with lower case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun test(modifier: Modifier): Unit {
+        Text(text = "3")
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings shouldHaveSize 1
+  }
+
+  should("not report when returns Unit and starts with upper case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(modifier: Modifier) {
+        Text(text = "3")
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("not report when returns Unit explicitly and starts with upper case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(modifier: Modifier): Unit {
+        Text(text = "3")
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("report when returns Int inline and starts with upper case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(modifier: Modifier) = 3
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings shouldHaveSize 1
+  }
+
+  should("report when returns Int explicitly inline and starts with upper case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(modifier: Modifier): Int = 3
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings shouldHaveSize 1
+  }
+
+  should("report when returns Int and starts with upper case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(modifier: Modifier): Int{
+        return 3
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings shouldHaveSize 1
+  }
+
+  should("not report when returns Int inline and starts with lower case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun test(modifier: Modifier) = 3
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("not report when returns Int explicitly inline and starts with lower case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun test(modifier: Modifier): Int = 3
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("not report when returns Int and starts with lower case") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun test(modifier: Modifier): Int {
+        return 3
+      }
+    """.trimIndent()
+
+    val findings = ComposeFunctionName().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+})


### PR DESCRIPTION
Functions that return `Unit` should start with upper case and if they return something different than `Unit` they should start with lower case.

I'm not checking the rest of the name as there are already other rules on detekt that check that. But I could change that and do pattern check with all the Composable function, it wouldn't be too difficult.

Closes #10