### PR TITLE
implement UnnecessaryLayoutWrapper rule

### DIFF
--- a/src/main/kotlin/ru/kode/detekt/rule/compose/UnnecessaryLayoutWrapper.kt
+++ b/src/main/kotlin/ru/kode/detekt/rule/compose/UnnecessaryLayoutWrapper.kt
@@ -1,0 +1,75 @@
+package ru.kode.detekt.rule.compose
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
+import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
+
+class UnnecessaryLayoutWrapper(config: Config = Config.empty) : Rule(config) {
+
+  override val issue: Issue = Issue(
+    javaClass.simpleName,
+    Severity.CodeSmell,
+    "Reports when Box, Column or Row is used as an unnecessary wrapper",
+    Debt.FIVE_MINS
+  )
+
+  private val layoutNames = setOf("Box", "Column", "Row")
+
+  private val unnecessaryExpressions = mutableListOf<KtCallExpression>()
+
+  override fun visitCallExpression(expression: KtCallExpression) {
+    val isLayout = layoutNames.any { it == expression.referenceName }
+    val hasNoParameters = expression.valueArgumentList == null
+    val hasSingleChildLayout = expression.lambdaBlock?.hasSingleLayout() ?: false
+    if (isLayout && hasNoParameters && hasSingleChildLayout) {
+      unnecessaryExpressions.add(expression)
+    }
+
+    super.visitCallExpression(expression)
+  }
+
+  private fun KtBlockExpression.hasSingleLayout(): Boolean {
+    val callExpressions = this.callExpressions
+    if (callExpressions.size != 1) return false
+    val referencedName =
+      (callExpressions[0].calleeExpression as? KtNameReferenceExpression)?.getReferencedName()
+    return layoutNames.any { it == referencedName }
+  }
+
+  override fun preVisit(root: KtFile) {
+    unnecessaryExpressions.clear()
+  }
+
+  override fun postVisit(root: KtFile) {
+    unnecessaryExpressions.forEach { expression ->
+      report(
+        CodeSmell(
+          issue,
+          Entity.from(expression),
+          "${expression.referenceName} is used as an unnecessary wrapper. " +
+            "Its child layout must be used directly"
+        )
+      )
+    }
+  }
+
+  private val KtCallExpression.lambdaBlock
+    get() = this.getChildOfType<KtLambdaArgument>()?.getLambdaExpression()?.bodyExpression
+
+  private val KtCallExpression.referenceName
+    get() = (this.calleeExpression as? KtNameReferenceExpression)?.getReferencedName()
+
+  private val KtBlockExpression.callExpressions
+    get() = this.getChildrenOfType<KtCallExpression>()
+}

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -22,3 +22,5 @@ compose:
     active: false
   ComposableFunctionName:
     active: true
+  UnnecessaryLayoutWrapper:
+    active: true

--- a/src/test/kotlin/ru/kode/detekt/rule/compose/UnnecessaryLayoutWrapperTest.kt
+++ b/src/test/kotlin/ru/kode/detekt/rule/compose/UnnecessaryLayoutWrapperTest.kt
@@ -1,0 +1,216 @@
+package ru.kode.detekt.rule.compose
+
+import io.gitlab.arturbosch.detekt.test.lint
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+
+class UnnecessaryLayoutWrapperTest : ShouldSpec({
+  should("not report when parent layout with any parameter has single child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Row(modifier = Modifier.size(200.dp)) {
+          Column {
+      
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("not report when child layout with any parameter has its own single child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Box(modifier = Modifier.size(200.dp)) {
+          Box(modifier = Modifier.size(200.dp)) {
+            Row {
+      
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("not report when parent parameterless layout has 2 or more child layouts") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Box {
+          Box {
+      
+          }
+          Column {
+      
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldBeEmpty()
+  }
+
+  should("report when parent parameterless layout has single child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Box {
+          Row {
+      
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(1)
+  }
+
+  should("report when child parameterless layout has its own single child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Column(modifier = Modifier.size(200.dp)) {
+          Column {
+            Box(modifier = Modifier.size(200.dp)) {
+      
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(1)
+  }
+
+  should("report when any of child parameterless layouts have their own single child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Box(modifier = Modifier.size(200.dp)) {
+          Box {
+            Box(modifier = Modifier.size(200.dp)) {
+      
+            }
+          }
+          Column {
+      
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(1)
+  }
+
+  should("report when 2 or more child parameterless layouts have their own single child layouts") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        Box(modifier = Modifier.size(200.dp)) {
+          Box {
+            Box(modifier = Modifier.size(200.dp)) {
+      
+            }
+          }
+          Column {
+            Column(modifier = Modifier.size(200.dp)) {
+      
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(2)
+  }
+
+  should("report when function has default lambda parameter with parameterless layout having child layout") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test(
+        paramLambda: @Composable () -> Unit = {
+          Box {
+            Column {
+        
+            } 
+          }
+        }
+      ) {
+      
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(1)
+  }
+
+  should("report when parameterless layout has child layout passed to another function's lambda argument") {
+    // language=kotlin
+    val code = """
+      @Composable
+      fun Test() {
+        OtherComposable(
+          slot1 = {
+            Row {
+              Row {
+      
+              }
+            }
+          },
+          slot2 = {
+            Column(horizontalAlignment = Alignment.End) {
+              Box {
+      
+              }
+            }
+          },
+          a = 1,
+          b = "test"
+        )
+      }
+
+      @Composable
+      fun OtherComposable(
+        slot1: @Composable () -> Unit,
+        slot2: @Composable () -> Unit,
+        a: Int,
+        b: String
+      ) {
+        Text(text = "test")
+      }
+    """.trimIndent()
+
+    val findings = UnnecessaryLayoutWrapper().lint(code)
+
+    findings.shouldHaveSize(1)
+  }
+})


### PR DESCRIPTION
The rule reports if the use of Box, Column or Row is not required. For example, in code below, we can easily remove the parent column.
```
Column {
    Box(modifier = Modifier.size(200.dp)) {
        // Other content
    }
}
```