### PR TITLE
 Improve ReusedModifierInstance 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
   useJUnitPlatform()
+  systemProperty("compile-snippet-tests", true)
   testLogging {
     showExceptions = true
     showStandardStreams = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.6.20"
+  kotlin("jvm") version "1.7.21"
   `maven-publish`
   signing
   alias(libs.plugins.spotless)
@@ -140,7 +140,9 @@ spotless {
     targetExclude("!**/build/**/*.*")
     ktlint(libs.versions.ktlint.get())
       .setUseExperimental(true)
-      .userData(mapOf("indent_size" to "2", "max_line_length" to "120"))
+      .editorConfigOverride(
+        mapOf("indent_size" to "2", "max_line_length" to "120")
+      )
     trimTrailingWhitespace()
     endWithNewline()
   }
@@ -149,7 +151,9 @@ spotless {
     target("**/*.gradle.kts")
     ktlint(libs.versions.ktlint.get())
       .setUseExperimental(true)
-      .userData(mapOf("indent_size" to "2", "max_line_length" to "120"))
+      .editorConfigOverride(
+        mapOf("indent_size" to "2", "max_line_length" to "120")
+      )
     trimTrailingWhitespace()
     endWithNewline()
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 detekt = "1.20.0"
-koTest = "5.2.3"
-ktlint = "0.43.2"
-spotless = "6.5.2"
+koTest = "5.5.4"
+ktlint = "0.47.1"
+spotless = "6.12.0"
 dokka = "1.5.31"
 
 [libraries]

--- a/src/main/kotlin/ru/kode/detekt/rule/compose/ModifierHeightWithText.kt
+++ b/src/main/kotlin/ru/kode/detekt/rule/compose/ModifierHeightWithText.kt
@@ -87,7 +87,7 @@ class ModifierHeightWithText(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun reportError(node: KtValueArgument) {
-      val heightCall = node.findDescendantOfType<KtCallExpression>() { it.calleeExpression?.text == "height" }
+      val heightCall = node.findDescendantOfType<KtCallExpression> { it.calleeExpression?.text == "height" }
         ?: error("didn't find height-call node")
       report(
         CodeSmell(

--- a/src/test/kotlin/ru/kode/detekt/rule/compose/snippet/ComposeSnippetWrappers.kt
+++ b/src/test/kotlin/ru/kode/detekt/rule/compose/snippet/ComposeSnippetWrappers.kt
@@ -1,0 +1,42 @@
+package ru.kode.detekt.rule.compose.snippet
+
+/**
+ * Appends a "fake" compose functions/classes/imports to mimic ones provided by Compose framework.
+ *
+ * This is required, because at the moment Detekt doesn't support adding custom plugins when it builds
+ * BindingContext and while Compose libraries can be added on classpath through testImplementation in build.gradle,
+ * but snippets won't compile without the Compose plugin.
+ *
+ * TODO: create a detekt-repo issue to request support for configuring BindingContext with custom compiler plugins
+ */
+fun composeSnippet(code: String): String {
+  return """
+      package ru.kode.detekt.rule
+
+      @Target(
+          AnnotationTarget.FUNCTION,
+          AnnotationTarget.TYPE,
+          AnnotationTarget.TYPE_PARAMETER,
+          AnnotationTarget.PROPERTY_GETTER
+      )
+      annotation class Composable
+      data class Dp(val v: Int)
+      val Int.dp get() = Dp(this)
+      interface Modifier {
+        fun weight(v: Float): Modifier { TODO() }
+        fun fillMaxSize(): Modifier { TODO() }
+        fun padding(horizontal: Dp, vertical: Dp): Modifier { TODO() }
+        fun padding(all: Dp): Modifier { TODO() }
+      }
+      val Modifier = object : Modifier {
+      }
+      enum class Alignment { CenterVertically }
+
+      @Composable fun Row(modifier: Modifier = Modifier, verticalAlignment: Alignment = Alignment.CenterVertically, content: () -> Unit) {}
+      @Composable fun Column(modifier: Modifier = Modifier, verticalAlignment: Alignment = Alignment.CenterVertically, content: () -> Unit) {}
+      @Composable fun Box(modifier: Modifier = Modifier, content: () -> Unit) {}
+      @Composable fun Text(modifier: Modifier = Modifier, text: String) {}
+
+      $code
+  """.trimIndent()
+}


### PR DESCRIPTION
This rule now uses type resolution to be smarter and is now able to
correctly detekt when a composable call does not have a modifier
parameter at all, and will not report usage of `modifier` in composable
children of this call as an error.

Fixes https://github.com/appKODE/detekt-rules-compose/issues/5