### PR TITLE
Fixing incorrect rule name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are some highlights of rules in this rule set:
 
 - `TopLevelComposableFunctions` ensures that all composable functions are top-level functions (disabled by default)
 
-- `ComposeFunctionName` ensures that Composable functions which return Unit should start with upper-case while the ones that return a value should start with lower case
+- `ComposableFunctionName` ensures that Composable functions which return Unit should start with upper-case while the ones that return a value should start with lower case
 
 - and others...
 
@@ -66,7 +66,7 @@ compose:
     active: true
   TopLevelComposableFunctions:
     active: true
-  ComposeFunctionName:
+  ComposableFunctionName:
     active: true
 ```
 


### PR DESCRIPTION
The copy/paste section of the readme has a typo in it (Compose -> Composable). 

I had copied this is into the detekt yaml file in my project, and turned off `ComposeFunctionName`, only to find that the errors persisted. The new name of the rule seems to be `ComposableFunctionName`. Things worked as expected after updating my yaml file to be 
```yaml
ComposableFunctionName: 
  active: false
```

---

For context on why I wanted to turn it off - some of the preview composables in my project forward to other composables that return Unit, or use themes which return Unit. The error will go off for things like this 
```kotlin
RedButton(text: String) = BaseButton(text, Color.Red)
```
and this
```kotlin
@Preview MyButtonOnLight() = PreviewThemeLight { RedButton("Hello") }
@Preview MyButtonOnDark() = PreviewThemeDark { RedButton("Hello") }
```
